### PR TITLE
GetMasterHost should not return port

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -257,7 +257,7 @@ type ContainerFailures struct {
 func GetMasterHost() string {
 	masterUrl, err := url.Parse(TestContext.Host)
 	ExpectNoError(err)
-	return masterUrl.Host
+	return masterUrl.Hostname()
 }
 
 func nowStamp() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
E2E performance test need pass --host option, but it failed to parse hostname.

**Special notes for your reviewer**:
@ypnuaa037 
