### PR TITLE
fix rbd volume plugin ConstructVolume

### DIFF
--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -357,7 +357,12 @@ func getDeviceNameFromMount(mounter Interface, mountPath, pluginDir string) (str
 		glog.V(4).Infof("Directory %s is not mounted", mountPath)
 		return "", fmt.Errorf("directory %s is not mounted", mountPath)
 	}
+
 	basemountPath := path.Join(pluginDir, MountsInGlobalPDPath)
+        if strings.Contains(mountPath, "kubernetes.io~rbd") {
+                basemountPath = path.Join(pluginDir, "rbd")
+        }
+
 	for _, ref := range refs {
 		if strings.HasPrefix(ref, basemountPath) {
 			volumeID, err := filepath.Rel(basemountPath, ref)


### PR DESCRIPTION
Fix rbd volume plugin ConstructVolume and specifically adapt
RBD plugin mount path prefix

There is a common mount path for all of other plugins as:
"{pluginName}/mounts/...". However, RBD plugin use the global
mount path as "{pluginName}/rbd/...".

For backward compatibility, add a if statement here to bypass
RBD mount path error.

**What this PR does / why we need it**:

1. rbd plugin.ConstructVolumeSpec() construct volume spec with fake value, cause kubelet volume manager will create two volumesInUse in node Status.

2. change plugin.GetVolumeName(), create volumeName using rbd pool instead of monitors, because monitors is a group of IPs, which makes the volumeName too long. Also, this is to fit plugin.ConstructVolumeSpec() since makeGlobalPDName only uses rbd pool and image.

```
before fix:
volumesAttached:
  - devicePath: ""
    name: kubernetes.io/rbd/[xxxxxxx:6789 xxxxxxxxx:6789]:volume-9a106847-4def-4d1e-9603-4c7099b22a31
  volumesInUse:
  - 'kubernetes.io/rbd/[]:'
  - kubernetes.io/rbd/[xxxxxxx:6789 xxxxxxxxx:6789]:volume-9a106847-4def-4d1e-9603-4c7099b22a31

after fix:
volumesAttached:
  - devicePath: ""
    name: kubernetes.io/rbd/volumes:volume-9a106847-4def-4d1e-9603-4c7099b22a31
  volumesInUse:
  - kubernetes.io/rbd/volumes:volume-9a106847-4def-4d1e-9603-4c7099b22a31
```
**Which issue(s) this PR fixes** :
Fixes #EAS-22814

**Special notes for your reviewer**:

```release-note
the format of volumeInUse and volumeAttached has been changed since this patch
```
