### PR TITLE
Avoid volume unexpected deleted from DSW by DSWP when kubelet start

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -76,6 +76,9 @@ type ActualStateOfWorld interface {
 	// attached volumes, an error is returned.
 	SetVolumeGloballyMounted(volumeName v1.UniqueVolumeName, globallyMounted bool, devicePath, deviceMountPath string) error
 
+	// IsVolumeBindMounted return false if a volume has not been bind mounted yet
+	IsVolumeBindMounted(volumeName v1.UniqueVolumeName, podName volumetypes.UniquePodName) bool
+
 	// DeletePodFromVolume removes the given pod from the given volume in the
 	// cache indicating the volume has been successfully unmounted from the pod.
 	// If a pod with the same unique name does not exist under the specified
@@ -577,6 +580,25 @@ func (asw *actualStateOfWorld) SetVolumeGloballyMounted(
 	}
 	asw.attachedVolumes[volumeName] = volumeObj
 	return nil
+}
+
+func (asw *actualStateOfWorld) IsVolumeBindMounted(
+	volumeName v1.UniqueVolumeName, podName volumetypes.UniquePodName) bool {
+	asw.Lock()
+	defer asw.Unlock()
+	volumeObj, volumeExists := asw.attachedVolumes[volumeName]
+	if !volumeExists {
+		 klog.V(4).Infof(
+			"no volume with the name %q exists in the list of attached volumes when check volume is bind mounted",
+			volumeName)
+		 return false
+	}
+	_, podExists := volumeObj.mountedPods[podName]
+	if podExists {
+		return true
+	} else {
+		return false
+	}
 }
 
 func (asw *actualStateOfWorld) DeletePodFromVolume(

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -258,13 +258,14 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 				format.Pod(volumeToMount.Pod))
 			continue
 		}
-		exists, _, _ := dswp.actualStateOfWorld.PodExistsInVolume(volumeToMount.PodName, volumeToMount.VolumeName)
+		exists := dswp.actualStateOfWorld.IsVolumeBindMounted(volumeToMount.VolumeName, volumetypes.UniquePodName(volumeToMount.Pod.UID))
 		if !exists && podExists {
 			klog.V(4).Infof(
 				volumeToMount.GenerateMsgDetailed(fmt.Sprintf("Actual state has not yet has this volume mounted information and pod (%q) still exists in pod manager, skip removing volume from desired state",
 					format.Pod(volumeToMount.Pod)), ""))
 			continue
 		}
+
 		klog.V(4).Infof(volumeToMount.GenerateMsgDetailed("Removing volume from desired state", ""))
 
 		dswp.desiredStateOfWorld.DeletePodFromVolume(


### PR DESCRIPTION
When kubelet starts, pods will be evicted and it may take more time to
reconcile the status in ASW and DSW. When volume is added to ASW and
marked as attached, it may quickly delete by another goroutine DSWP
which leads to volume disapear from ASW and DSW.

Add a requirement here to ask Attachable volume plugin has to be marked
as globally mounted to ensure it won't been deleted by DSWP.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
